### PR TITLE
fixed link to contributing.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ docsify serve docs
 > To get started...
 
 1.  🍴 [Fork this repo](https://github.com/fvcproductions/hire-me#fork-destination-box)
-2.  🔨 View the contributing guidelines at [CONTRIBUTING.md](/.github/CONTRIBUTING.md)
+2.  🔨 View the contributing guidelines at [CONTRIBUTING.md](/CONTRIBUTING.md)
 3.  👥 Add yourself as a contributor under the credits section
 4.  🔧 [Open a new pull request](https://github.com/fvcproductions/hire-me/compare)
 5.  🎉 Get your pull request approved - success!


### PR DESCRIPTION
The contributing.md link was linking to an outdated location. Updated to reflect its current location so that the link works. 

---

<!-- Thank you for contributing to this repo, it is much appreciated! 😊 -->

<!-- Before creating a PR, make sure to verify the following. -->

## ✅️ By submitting this PR, I have verified the following

### Guidelines

#### Content

> If adding new advice or content,

* [x] A tool like [Grammarly](https://grammarly.com/) was utilized to check for spelling and grammar.

#### Resources

> If adding a new resource,

* [x] There is a link to the resource.
* [x] There is a description describing what benefits the resource offers.

### Formatting

* [x] No whitespace.
* [x] Spaces, not tabs. Specifically, 2 spaces.
* [x] Make sure items in lists are alphabetized.

### Adding yourself as a contributor.

* [z] Added my name to the bottom of the list under the _Credits_ section in the `README.md` with a link to my website or GitHub profile 👥️
