### PR TITLE
docs: add Hanzilla Jobs to job boards

### DIFF
--- a/docs/02-search/README.md
+++ b/docs/02-search/README.md
@@ -56,6 +56,7 @@ Here are some websites you can use when looking for open positions.
 - [GarysGuide](http://www.garysguide.com/jobs)
 - [GitHub Jobs](https://jobs.github.com/positions)
 - [Glassdoor Jobs](https://www.glassdoor.com/index.htm)
+- [Hanzilla Jobs](https://jobs.hanzilla.co/new-grad/) 🎓 - daily-updated Canadian student and recent-grad roles across internships, co-ops, new grad, junior, and entry-level positions
 - [Hiring Without Whiteboards - GitHub Repo](https://github.com/poteto/hiring-without-whiteboards)
 - [Indeed](https://www.indeed.com/)
 - [Landing.jobs](https://landing.jobs/)


### PR DESCRIPTION
## Summary
- Add Hanzilla Jobs to the Step 2 job-board list as a student/recent-grad focused resource.
- Use the `/new-grad/` landing page because it is a direct fit for early-career job seekers.

## Why this fits
Hanzilla Jobs is a free, daily-updated Canadian student/recent-grad jobs board covering internships, co-ops, new grad, junior, and entry-level roles across tech, finance, engineering, business, sciences, and related fields.

## Verification
- Verified `https://jobs.hanzilla.co/new-grad/` returns 200, has a self-canonical URL, and is not marked `noindex`.
- Ran `git diff --check`.
