### PR TITLE
Add HireMe bookmark resources across all docs sections

### DIFF
--- a/docs/01-prepare/README.md
+++ b/docs/01-prepare/README.md
@@ -160,3 +160,18 @@ With [Pramp](https://www.pramp.com/#/), you can practice coding interviews live 
 ## Further Resources
 
 - [Udacity Career Resource Center](https://career-resource-center.udacity.com/)
+- [Tech Interview Handbook](https://github.com/yangshun/tech-interview-handbook) - Curated coding interview preparation materials for busy software engineers
+- [Tech Interview Handbook Portal](https://app.techinterviewhandbook.org/) - Interactive portal for the Tech Interview Handbook
+- [Front End Interview Handbook](https://www.frontendinterviewhandbook.com/) - Front end interview preparation for busy engineers
+- [ByteByteGo](https://bytebytego.com/) - System design interview prep
+- [AlgoMonster](https://algo.monster/) - Conquer the coding interview; master algorithms and data structures
+- [Design Gurus](https://designgurus.org/home) - Ace the system design and coding interview
+- [FAANG Tech Leads](https://www.faangtechleads.com/) - Software engineer resume review
+- [Interview Cake](https://www.interviewcake.com/) - Programming interview questions and job offer prep
+- [CodeSignal Interview Practice](https://codesignal.com/developers/interview-practice/) - Practice for technical interviews
+- [CoderPad](https://coderpad.io/) - Live coding interview platform
+- [No Whiteboard](https://www.nowhiteboard.org/) - Companies that don't use whiteboard interviews
+- [hiring-without-whiteboards](https://github.com/poteto/hiring-without-whiteboards) - Companies that don't have a broken hiring process
+- [freeCodeCamp - How to Contribute to Open Source](https://github.com/freeCodeCamp/how-to-contribute-to-open-source) - A guide to contributing to open source
+- [Netflix Pathways Bootcamp](https://netflix.edx.org/) - Netflix engineering bootcamp program
+- [A Senior Engineer's Guide to FAANG Interviews](https://interviewing.io/guides/hiring-process) - Comprehensive interview process guide

--- a/docs/02-search/README.md
+++ b/docs/02-search/README.md
@@ -42,7 +42,7 @@ Here are some websites you can use when looking for open positions.
 
 ---
 
-- [Angel.co Jobs](https://angel.co/jobs)
+- [Angel.co Jobs](https://angel.co/jobs) / [Wellfound](https://wellfound.com/jobs)
 - [BainCapital Ventures](http://jobs.baincapitalventures.com/) 💸️
 - [Behance Jobs](https://www.behance.net/joblist) 🎨
 - [BetaList Jobs](https://betalist.com/jobs)
@@ -78,6 +78,17 @@ Here are some websites you can use when looking for open positions.
 - [Women Who Code Jobs](https://www.womenwhocode.com/jobs) 🚺️
 - [YCombinator Jobs](https://news.ycombinator.com/jobs) 💸️
 - [ZipRecruiter](https://www.ziprecruiter.com/)
+- [Otta](https://otta.com/) - The better way to find a job in tech
+- [Hired](https://hired.com/) - Tech job hunting marketplace
+- [Tribaja](https://www.tribaja.co/) - Job board for diverse tech talent
+- [Elpha Talent Pool](https://elpha.com/talent-pool) - Let your dream role come to you 🚺️
+- [cord](https://cord.co/) - The messaging tool for finding work
+- [Tech Ladies](https://www.hiretechladies.com/) - Hire more women in tech 🚺️
+- [Hatchways](https://www.hatchways.io/) - Connecting developers with companies
+- [Responsible Tech Job Board](https://alltechishuman.org/responsible-tech-job-board) - All Tech Is Human
+- [Who's Still Hiring?](https://stillhiring.today/) - Find a tech job with open roles
+- [Work at a Startup](https://www.workatastartup.com/) - YC-backed startup jobs 💸️
+- [Levels.fyi Jobs](https://www.levels.fyi/jobs/location/united-states/title/software-engineer/level/mid_staff?workArrangements=remote) - Software engineering jobs with compensation data
 
 ## Job Tracking
 
@@ -118,3 +129,7 @@ The [JobHero](https://gojobhero.com/app/) dashboard allows you to
 [Trello](https://trello.com/) keeps track of everything, from the big picture to the minute details.
 
 ![Trello](https://i.imgur.com/U3IMAlX.png)
+
+### Comprehensive.io
+
+[Comprehensive.io](https://www.comprehensive.io/) is a pay range tracker that helps you understand compensation at companies before you apply.

--- a/docs/03-apply/README.md
+++ b/docs/03-apply/README.md
@@ -39,3 +39,11 @@ I would recommend using an online platform like [Creddle](http://creddle.io/) to
 [Canva](https://www.canva.com/create/resumes/) also offers a free way to create a compelling resume design that organizes all your credentials in an impressive run-through.
 
 ![Canva](https://i.imgur.com/HaiOjv1.png)
+
+### Resume Worded
+
+[Resume Worded](https://resumeworded.com/) provides free instant feedback on your resume and LinkedIn profile to help you land more interviews.
+
+### FAANG Tech Leads
+
+[FAANG Tech Leads](https://www.faangtechleads.com/) offers resume review services from engineers at FAANG companies to help you stand out.

--- a/docs/04-interview/README.md
+++ b/docs/04-interview/README.md
@@ -9,3 +9,12 @@
 - being prepared to answer the behavioral questions the interviewer may ask
 - **always always** asking questions
 - following up
+
+## Interview Platforms
+
+These are platforms companies use to conduct technical interviews — knowing them in advance can help you feel more comfortable.
+
+- [CoderPad](https://coderpad.io/) - Live coding interview platform used by many companies
+- [Karat](https://karat.com/) - The Interviewing Cloud; accelerates technical hiring
+- [Woven Teams](https://www.woventeams.com/) - Technical interview software for developers
+- [Interviewing.io](https://interviewing.io/?urc=DMCa) - Practice mock interviews anonymously with engineers from FAANG and more

--- a/docs/05-accept/salary.md
+++ b/docs/05-accept/salary.md
@@ -8,6 +8,14 @@ These are a few sentences I took from the book, [Fearless Salary Negotiation](ht
 >
 > I want this move to be a big step forward for me in terms of both responsibility and compensation.
 
+## Salary Research Tools
+
+Before negotiating, research what the market pays for your role:
+
+- [Levels.fyi](https://www.levels.fyi/jobs/location/united-states/title/software-engineer/level/mid_staff?workArrangements=remote) - Compensation data and job listings at tech companies
+- [Comprehensive.io](https://www.comprehensive.io/) - Pay range tracker crowdsourced from real employees
+- [Rora](https://www.teamrora.com/?utm_source=techinterviewhandbook&utm_medium=referral&utm_content=) - Salary negotiation coaching for tech professionals
+
 ## Fearless Salary Negotiaton
 
 To really learn how to negotiate your salary, I would read that book [Fearless Salary Negotiation](http://fearlesssalarynegotiation.com/).


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

Integrates all bookmarks from the HireMe 💼 browser folder into the relevant docs sections:

- **01-prepare**: ByteByteGo, AlgoMonster, Design Gurus, FAANG Tech Leads, Front End Interview Handbook, Tech Interview Handbook (yangshun), CodeSignal, No Whiteboard, hiring-without-whiteboards, Netflix Pathways Bootcamp, CoderPad, Interview Cake, freeCodeCamp OSS guide, interviewing.io senior engineer guide
- **02-search**: Wellfound (AngelList), Otta, Hired, Tribaja, Elpha Talent Pool, cord, Tech Ladies, Hatchways, Responsible Tech Job Board, Who's Still Hiring, Work at a Startup (YC), Levels.fyi Jobs, Comprehensive.io pay tracker
- **03-apply**: Resume Worded (instant resume feedback), FAANG Tech Leads resume review
- **04-interview**: CoderPad, Karat, Woven Teams, Interviewing.io mock interviews
- **05-accept**: Levels.fyi compensation data, Comprehensive.io pay ranges, Rora salary negotiation coaching

## Test plan

- [ ] Review each docs section to verify links are correct and placed in appropriate sections
- [ ] Confirm no duplicate entries with existing content

https://claude.ai/code/session_01TWg5N4wcHgtvCEYLG3pNuc
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01TWg5N4wcHgtvCEYLG3pNuc)_